### PR TITLE
Terminate the app middleware

### DIFF
--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -64,7 +64,6 @@ class Laravel5 extends Client implements HttpKernelInterface, TerminableInterfac
 	 */
 	public function terminate(DomRequest $request, Response $response)
 	{
-		$kernel = $this->app->make('Illuminate\Contracts\Http\Kernel');
-		$kernel->terminate($request, $response);
+		$this->httpKernel->terminate($request, $response);
 	}
 }


### PR DESCRIPTION
From the discussion at <a href="https://laracasts.com/discuss/channels/general-discussion/l5-codecept-broken-since-bootstrapstartphp-removed">laracast</a> I found that the middleware isn't terminated properly. This fixes it.
