### PR TITLE
Added disconnecting from DB to prevent "Too many connections" issue

### DIFF
--- a/src/Codeception/Module/Laravel5.php
+++ b/src/Codeception/Module/Laravel5.php
@@ -117,6 +117,11 @@ class Laravel5 extends Framework implements ActiveRecord
         if ($this->app['session']) {
             $this->app['session']->flush();
         }
+
+        // disconnect from DB to prevent "Too many connections" issue
+        if ($this->app['db']) {
+            $this->app['db']->disconnect();
+        }
     }
 
     /**
@@ -192,7 +197,7 @@ class Laravel5 extends Framework implements ActiveRecord
 
         return $app;
     }
-	
+
 	/**
      * Provides access the Laravel application object.
      *


### PR DESCRIPTION
If this line is no present for 170 tests I get:
````
 [PDOException]                               
 SQLSTATE[08004] [1040] Too many connections
````

For lower number of tests there is no problem of course and I don't want to increase my database connections limit.

As far as I know it's impossible to disconnect in test in ```__after``` method because in that case you will get fatal error "Call to a member function rollBack() on null"