### PR TITLE
Fix issue with incorrectly generated urls due to bogus request hostname

### DIFF
--- a/src/Codeception/Lib/Connector/Laravel5.php
+++ b/src/Codeception/Lib/Connector/Laravel5.php
@@ -30,6 +30,24 @@ class Laravel5 extends Client implements HttpKernelInterface, TerminableInterfac
         $this->app->boot();
         parent::__construct($this);
     }
+
+    /**
+     * Sets server parameters.
+     *
+     * @param array $server An array of server parameters
+     *
+     * @api
+     */
+    public function setServerParameters(array $server)
+    {
+        $appUrl = $this->app['config']->get('app.url', 'http://localhost');
+        $appUrl = rtrim(preg_replace('/^https?\:\/\//', '', $appUrl), '/');
+
+        parent::setServerParameters(array_merge(array(
+            'HTTP_HOST' => $appUrl,
+        ), $server));
+    }
+    
     /**
      * Handle a request.
      *


### PR DESCRIPTION
Generated urls via `url('...')` or `URL::to('..')` should respect the 'app.url' config value as the root of the url over that of the request.

For relative url requests (99% of urls in tests are relative) the Laravel5 client class infers the hostname, defaulting to the configured `$this->server['HTTP_HOST']`. The default of this value is 'localhost' which is usually fine but is incorrect when the 'app.url' is set otherwise.

This patch sets the default HTTP_HOST value to that of the configured 'app.url' which then produces requests coming from the expected hostname.
